### PR TITLE
fix: is_select check for lowercase select with "WITH" clauses

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -228,7 +228,7 @@ class ParsedQuery:
         # for `UNKNOWN`, check all DDL/DML explicitly: only `SELECT` DML is allowed,
         # and no DDL is allowed
         if any(token.ttype == DDL for token in parsed[0]) or any(
-            token.ttype == DML and token.value != "SELECT" for token in parsed[0]
+            token.ttype == DML and token.normalized != "SELECT" for token in parsed[0]
         ):
             return False
 
@@ -237,7 +237,7 @@ class ParsedQuery:
             return False
 
         return any(
-            token.ttype == DML and token.value == "SELECT" for token in parsed[0]
+            token.ttype == DML and token.normalized == "SELECT" for token in parsed[0]
         )
 
     def is_valid_ctas(self) -> bool:

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1006,6 +1006,27 @@ SELECT
 FROM foo f"""
     )
     assert sql.is_select()
+    
+def test_cte_is_select_lowercase() -> None:
+    """
+    Some CTEs with lowercase select are not correctly identified as SELECTS.
+    """
+    sql = ParsedQuery(
+        """WITH foo AS(
+select
+  FLOOR(__time TO WEEK) AS "week",
+  name,
+  COUNT(DISTINCT user_id) AS "unique_users"
+FROM "druid"."my_table"
+GROUP BY 1,2
+)
+select
+  f.week,
+  f.name,
+  f.unique_users
+FROM foo f"""
+    )
+    assert sql.is_select()
 
 
 def test_unknown_select() -> None:

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1006,7 +1006,8 @@ SELECT
 FROM foo f"""
     )
     assert sql.is_select()
-    
+
+
 def test_cte_is_select_lowercase() -> None:
     """
     Some CTEs with lowercase select are not correctly identified as SELECTS.


### PR DESCRIPTION
Checking for token.normalized instead of token.value in is_select check, avoiding issues with lowercase select statements


### SUMMARY
is_select check in a ParsedQuery object fails to give true response when has multiple WITH clauses, such that sqlparse gives an UNKNOWN type for the query when the statement uses a lowercase "select" clause. This shouldn't happen as lowercase select statements are still select statements

### TESTING INSTRUCTIONS
test updating the metadata for a virtual dataset with "WITH" clause at the beginning with lowercase select statements

### ADDITIONAL INFORMATION

- [ x ] Has associated issue: https://github.com/apache/superset/issues/20565
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
